### PR TITLE
Repair test suite and run it in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,3 +20,6 @@ jobs:
     - name: npm install
       run: |
         npm install
+    - name: npm test
+      run: |
+        npm test

--- a/.mochaclicktest.json
+++ b/.mochaclicktest.json
@@ -1,6 +1,6 @@
 {
   "spec": "clicktests/spec.*.js",
-  "file": "./source/utils/logger.js",
+  "file": "./test/setup.js",
   "timeout": 20000,
   "bail": true,
   "exit": true

--- a/.mochatest.json
+++ b/.mochatest.json
@@ -1,6 +1,6 @@
 {
   "spec": "test/spec.*.js",
-  "file": "./source/utils/logger.js",
+  "file": "./test/setup.js",
   "timeout": 12000,
   "exit": true
 }

--- a/clicktests/environment.js
+++ b/clicktests/environment.js
@@ -60,7 +60,7 @@ class Environment {
 
     this.hasStarted = false;
     const options = [
-      'bin/ungit',
+      'bin/mungit',
       '--cliconfigonly',
       `--port=${this.port}`,
       `--rootPath=${this.config.rootPath}`,
@@ -86,7 +86,7 @@ class Environment {
           logger.info('server-already-running');
         }
 
-        if (stdoutStr.indexOf('## Ungit started ##') >= 0) {
+        if (stdoutStr.indexOf('## Mungit started ##') >= 0) {
           if (this.hasStarted) {
             reject(new Error('Ungit started twice, probably crashed.'));
           } else {
@@ -251,14 +251,14 @@ class Environment {
     return this.page.keyboard.press(key);
   }
 
-  async click(selector, clickCount) {
+  async click(selector, count) {
     logger.info(`clicking "${selector}"`);
 
     for (let i = 0; i < 3; i++) {
       try {
         const toClick = await this.waitForElementVisible(selector);
         await this.wait(200);
-        await toClick.click({ delay: 100, clickCount: clickCount });
+        await toClick.click({ delay: 100, count });
         break;
       } catch (err) {
         logger.error('error while clicking', err);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "inspect": "node --inspect ./source/server.js",
     "test": "npm run unittest && npm run clicktest",
     "unittest": "mocha --config .mochatest.json",
+    "preclicktest": "npm run build",
     "clicktest": "mocha --config .mochaclicktest.json",
     "coverage": "nyc npm run unittest",
     "lint": "eslint .",

--- a/public/scss/styles.scss
+++ b/public/scss/styles.scss
@@ -126,6 +126,10 @@ div.list-group-item {
 }
 
 .dropdown-menu {
+  > li {
+    position: relative;
+  }
+
   .linked-remove {
     padding-right: 40px;
   }
@@ -135,8 +139,9 @@ div.list-group-item {
   }
 
   .list-link {
-    float: right;
-    margin-top: -23px;
+    position: absolute;
+    right: 0;
+    top: 0;
     padding: 0 4px;
   }
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+require('../source/utils/logger');
+
+const gitConfigPath = path.join(os.tmpdir(), `mungit-test-gitconfig-${process.pid}`);
+
+fs.writeFileSync(
+  gitConfigPath,
+  [
+    '[user]',
+    '\tname = Mungit Test',
+    '\temail = mungit-test@example.com',
+    '[protocol "file"]',
+    '\tallow = always',
+    '[safe]',
+    '\tbareRepository = all',
+    '',
+  ].join(os.EOL)
+);
+
+process.env.GIT_CONFIG_GLOBAL = gitConfigPath;
+process.env.GIT_CONFIG_NOSYSTEM = '1';
+
+const gitConfigCount = Number(process.env.GIT_CONFIG_COUNT || 0);
+process.env[`GIT_CONFIG_KEY_${gitConfigCount}`] = 'safe.bareRepository';
+process.env[`GIT_CONFIG_VALUE_${gitConfigCount}`] = 'all';
+process.env.GIT_CONFIG_COUNT = String(gitConfigCount + 1);
+
+process.once('exit', () => {
+  fs.rmSync(gitConfigPath, { force: true });
+});


### PR DESCRIPTION
## Summary

- isolate Git identity and security configuration for test repositories
- update click tests for the mungit launcher and current Puppeteer behavior
- build generated assets before click tests and repair dropdown remove interactions
- run `npm test` in the Node CI workflow

## Test results

- 230 unit/REST tests passing, 2 pending
- 107 click tests passing, 1 pending
- 337 tests passing overall